### PR TITLE
Ensure PIL bitmaps have alpha: rotation background now transparent.

### DIFF
--- a/src/aturtle/shapes/bitmap.py
+++ b/src/aturtle/shapes/bitmap.py
@@ -63,7 +63,7 @@ class Shape(base.Shape):
         else:
             # No tkinter, PIL was imported successfully.
             source = filename if filename else io.BytesIO(base64.b64decode(data))
-            image = Image.open(source)
+            image = Image.open(source).convert('RGBA')
             width = image.width
             height = image.height
 

--- a/tests/fake_pil.py
+++ b/tests/fake_pil.py
@@ -23,6 +23,9 @@ class FakePILImage:
     def open(cls, *args, **kwargs):
         return cls(*args, **kwargs)
 
+    def convert(self, _format):
+        return self
+
     rotate = mock.Mock()
 
     @classmethod


### PR DESCRIPTION
Fixes #39.