### PR TITLE
Turtle forward methods no support the track_angle argument.

### DIFF
--- a/src/aturtle/turtle.py
+++ b/src/aturtle/turtle.py
@@ -92,13 +92,17 @@ class Turtle:
             self._lines.append(self._line_id)
 
 
-    async def async_forward(self, delta, *, down=None, speed=None,
-                            easing=None, fps=None, update=None):
+    async def async_forward(self, delta, *, down=None, track_angle=None,
+                            speed=None, easing=None, fps=None, update=None):
         """
         Animated move of the Turtle forward by `delta` in the direction set by
         its angle. Negative values move in the opposite direction.
 
         The `down` argument overrides the current down state, if not None.
+
+        When `track_angle` is true, movement tracks concurrent updates to the
+        Turtle's angle, potentially resulting in non-linear paths. Otherwise,
+        movement follows a straight line, set by the starting Turtle's angle.
 
         The `speed`, `easing`, `fps`, and `update` values are passed to the
         underlying Sprite's animated movement operation.
@@ -109,6 +113,7 @@ class Turtle:
             await self._sprite.async_forward(
                 delta,
                 callback=self._async_draw_line if self.down else None,
+                track_angle=track_angle,
                 speed=speed,
                 easing=easing,
                 fps=fps,

--- a/tests/test_turtle.py
+++ b/tests/test_turtle.py
@@ -225,6 +225,7 @@ class TestTurtleAsyncMovement(AsyncAnimationBase):
         self.sprite.async_forward.assert_awaited_with(
             42,
             callback=t._async_draw_line,
+            track_angle=None,
             speed=None,
             easing=None,
             fps=None,
@@ -238,6 +239,7 @@ class TestTurtleAsyncMovement(AsyncAnimationBase):
 
         coro = t.async_forward(
             42,
+            track_angle='track-angle',
             speed='speed',
             easing='easing',
             fps='fps',
@@ -248,6 +250,7 @@ class TestTurtleAsyncMovement(AsyncAnimationBase):
         self.sprite.async_forward.assert_awaited_with(
             42,
             callback=t._async_draw_line,
+            track_angle='track-angle',
             speed='speed',
             easing='easing',
             fps='fps',
@@ -278,6 +281,7 @@ class TestTurtleAsyncMovement(AsyncAnimationBase):
                 self.sprite.async_forward.assert_awaited_with(
                     42,
                     callback=expected_cb,
+                    track_angle=None,
                     speed=None,
                     easing=None,
                     fps=None,
@@ -546,6 +550,7 @@ class TestTurtleSyncMovement(SyncAnimationBase):
         self.sprite.sync_forward.assert_called_with(
             42,
             callback=t._sync_draw_line,
+            track_angle=None,
             speed=None,
             easing=None,
             fps=None,
@@ -559,6 +564,7 @@ class TestTurtleSyncMovement(SyncAnimationBase):
 
         t.sync_forward(
             42,
+            track_angle='track-angle',
             speed='speed',
             easing='easing',
             fps='fps',
@@ -568,6 +574,7 @@ class TestTurtleSyncMovement(SyncAnimationBase):
         self.sprite.sync_forward.assert_called_with(
             42,
             callback=t._sync_draw_line,
+            track_angle='track-angle',
             speed='speed',
             easing='easing',
             fps='fps',
@@ -597,6 +604,7 @@ class TestTurtleSyncMovement(SyncAnimationBase):
                 self.sprite.sync_forward.assert_called_with(
                     42,
                     callback=expected_cb,
+                    track_angle=None,
                     speed=None,
                     easing=None,
                     fps=None,


### PR DESCRIPTION
Fixes #68. :-)